### PR TITLE
Add additional operators to contact field check step

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -164,6 +164,11 @@
         "tslib": "^1.8.1"
       }
     },
+    "@run-crank/utilities": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/@run-crank/utilities/-/utilities-0.1.2.tgz",
+      "integrity": "sha512-9JGH72PWZveu7AzVwzACgq/7wSXZC+2C1n7yk0h1JnEKgd5DmNjIhnZ1KJWenPa2hFIpuUDBrreIQ/J2cT2u4A=="
+    },
     "@sinonjs/commons": {
       "version": "1.6.0",
       "resolved": "https://registry.npmjs.org/@sinonjs/commons/-/commons-1.6.0.tgz",

--- a/package.json
+++ b/package.json
@@ -55,6 +55,7 @@
     "typescript": "^3.5.1"
   },
   "dependencies": {
+    "@run-crank/utilities": "^0.1.2",
     "eloqua": "^1.3.0",
     "google-protobuf": "^3.8.0",
     "grpc": "^1.23.3",

--- a/src/core/base-step.ts
+++ b/src/core/base-step.ts
@@ -11,6 +11,7 @@ export interface Field {
   field: string;
   type: FieldDefinition.Type;
   description: string;
+  optionality?: FieldDefinition.Optionality;
 }
 
 export abstract class BaseStep {
@@ -37,9 +38,14 @@ export abstract class BaseStep {
       const expectedField = new FieldDefinition();
       expectedField.setType(field.type);
       expectedField.setKey(field.field);
-      expectedField.setOptionality(FieldDefinition.Optionality.REQUIRED);
       expectedField.setDescription(field.description);
       stepDefinition.addExpectedFields(expectedField);
+
+      if (field.hasOwnProperty('optionality')) {
+        expectedField.setOptionality(field.optionality);
+      } else {
+        expectedField.setOptionality(FieldDefinition.Optionality.REQUIRED);
+      }
     });
 
     return stepDefinition;

--- a/src/steps/contact-field-equals.ts
+++ b/src/steps/contact-field-equals.ts
@@ -3,6 +3,7 @@
 
 import { BaseStep, Field, StepInterface } from '../core/base-step';
 import { FieldDefinition, RunStepResponse, Step, StepDefinition } from '../proto/cog_pb';
+import * as util from '@run-crank/utilities';
 
 /**
  * Note: the class name here becomes this step's stepId.
@@ -26,7 +27,16 @@ export class ContactFieldEquals extends BaseStep implements StepInterface {
    * named regex capturing groups that correspond to the expected fields below.
    */
   // tslint:disable-next-line:max-line-length
-  protected stepExpression: string = 'the (?<field>.+) field on eloqua contact (?<email>.+) should be (?<expectedValue>.+)';
+  protected stepExpression: string = 'the (?<field>.+) field on eloqua contact (?<email>.+) should (?<operator>be less than|be greater than|be|contain|not be|not contain) (?<expectedValue>.+)';
+
+  protected supportedOperators: string[] = [
+    'be',
+    'not be',
+    'contain',
+    'not contain',
+    'be less than',
+    'be greater than',
+  ];
 
   /**
    * An array of Fields that this step expects to be passed via step data. The value of "field"
@@ -41,6 +51,11 @@ export class ContactFieldEquals extends BaseStep implements StepInterface {
     type: FieldDefinition.Type.STRING,
     description: 'Field name to check',
   }, {
+    field: 'operator',
+    type: FieldDefinition.Type.STRING,
+    optionality: FieldDefinition.Optionality.OPTIONAL,
+    description: 'Check Logic (be, not be, contain, not contain, be greater than, or be less than)',
+  }, {
     field: 'expectedValue',
     type: FieldDefinition.Type.ANYSCALAR,
     description: 'Expected field value',
@@ -51,33 +66,46 @@ export class ContactFieldEquals extends BaseStep implements StepInterface {
     const stepData: any = step.getData().toJavaScript();
     const email: string = stepData.email;
     const field: string = stepData.field;
+    const operator: string = (stepData.operator || 'be').toLowerCase();
     const expectedValue: string = stepData.expectedValue;
 
     try {
       apiRes = await this.client.searchContactsByEmail(email);
     } catch (e) {
-      return this.error('There was a problem connecting to JSON Placeholder.');
+      return this.error('There was a problem connecting to Eloqua: %s', [
+        e.toString(),
+      ]);
     }
 
-    if (apiRes.elements.length === 0) {
-      // If no results were found, return an error.
-      return this.error('No contact found for email %s', [email]);
-    } else if (!apiRes.elements[0].hasOwnProperty(field)) {
-      // If the given field does not exist on the user, return an error.
-      return this.error('The %s field does not exist on contact %s', [field, email]);
-    } else if (apiRes.elements[0][field] == expectedValue) {
-      // If the value of the field matches expectations, pass.
-      return this.pass('The %s field was set to %s, as expected', [
-        field,
-        apiRes.elements[0][field],
-      ]);
-    } else {
-      // If the value of the field does not match expectations, fail.
-      return this.fail('Expected %s field to be %s, but it was actually %s', [
-        field,
-        expectedValue,
-        apiRes.elements[0][field],
-      ]);
+    try {
+      if (apiRes.elements.length === 0) {
+        // If no results were found, return an error.
+        return this.error('No contact found for email %s', [email]);
+      } else if (!apiRes.elements[0].hasOwnProperty(field)) {
+        // If the given field does not exist on the contact, return an error.
+        return this.error('The %s field does not exist on contact %s', [field, email]);
+      } else if (util.compare(operator, apiRes.elements[0][field], expectedValue)) {
+        // If the value of the field meets expectations, pass.
+        return this.pass(util.operatorSuccessMessages[operator], [
+          field,
+          expectedValue,
+        ]);
+      } else {
+        // If the value of the field does not match expectations, fail.
+        return this.fail(util.operatorFailMessages[operator], [
+          field,
+          expectedValue,
+          apiRes.elements[0][field],
+        ]);
+      }
+    } catch (e) {
+      if (e instanceof util.UnknownOperatorError) {
+        return this.error('%s Please provide one of: %s', [e.message, this.supportedOperators.join(', ')]);
+      }
+      if (e instanceof util.InvalidOperandError) {
+        return this.error(e.message);
+      }
+      return this.error('There was an error checking the contact field: %s', [e.message]);
     }
   }
 

--- a/test/steps/contact-field-equals.ts
+++ b/test/steps/contact-field-equals.ts
@@ -27,7 +27,7 @@ describe('ContactFieldEquals', () => {
     const stepDef: StepDefinition = stepUnderTest.getDefinition();
     expect(stepDef.getStepId()).to.equal('ContactFieldEquals');
     expect(stepDef.getName()).to.equal('Check a field on an Eloqua contact');
-    expect(stepDef.getExpression()).to.equal('the (?<field>.+) field on eloqua contact (?<email>.+) should be (?<expectedValue>.+)');
+    expect(stepDef.getExpression()).to.equal('the (?<field>.+) field on eloqua contact (?<email>.+) should (?<operator>be less than|be greater than|be|contain|not be|not contain) (?<expectedValue>.+)');
     expect(stepDef.getType()).to.equal(StepDefinition.Type.VALIDATION);
   });
 

--- a/test/steps/contact-field-equals.ts
+++ b/test/steps/contact-field-equals.ts
@@ -47,6 +47,11 @@ describe('ContactFieldEquals', () => {
     expect(email.optionality).to.equal(FieldDefinition.Optionality.REQUIRED);
     expect(email.type).to.equal(FieldDefinition.Type.EMAIL);
 
+    // Operator field
+    const operator: any = fields.filter(f => f.key === 'operator')[0];
+    expect(operator.optionality).to.equal(FieldDefinition.Optionality.OPTIONAL);
+    expect(operator.type).to.equal(FieldDefinition.Type.STRING);
+
     // Expected Value field
     const expectedValue: any = fields.filter(f => f.key === 'expectedValue')[0];
     expect(expectedValue.optionality).to.equal(FieldDefinition.Optionality.REQUIRED);
@@ -116,6 +121,38 @@ describe('ContactFieldEquals', () => {
     // Stub a response that throws any exception.
     apiClientStub.searchContactsByEmail.throws();
     protoStep.setData(Struct.fromJavaScript({}));
+
+    const response: RunStepResponse = await stepUnderTest.executeStep(protoStep);
+    expect(response.getOutcome()).to.equal(RunStepResponse.Outcome.ERROR);
+  });
+
+  it('should respond with error if comparator throws unknown operator error', async () => {
+    // Stub a response with valid content.
+    const expectedContact: any = {someField: 'Expected Value'};
+    apiClientStub.searchContactsByEmail.resolves({elements: [expectedContact]});
+
+    protoStep.setData(Struct.fromJavaScript({
+      field: 'someField',
+      expectedValue: 'Any Value',
+      operator: 'unknown operator',
+      email: 'anything@example.com',
+    }));
+
+    const response: RunStepResponse = await stepUnderTest.executeStep(protoStep);
+    expect(response.getOutcome()).to.equal(RunStepResponse.Outcome.ERROR);
+  });
+
+  it('should respond with error if comparator throws invalid operand error', async () => {
+    // Stub a response with valid content.
+    const expectedContact: any = {someField: 'Expected Value'};
+    apiClientStub.searchContactsByEmail.resolves({elements: [expectedContact]});
+
+    protoStep.setData(Struct.fromJavaScript({
+      field: 'someField',
+      expectedValue: 'Non-numeric value',
+      operator: 'be greater than',
+      email: 'anything@example.com',
+    }));
 
     const response: RunStepResponse = await stepUnderTest.executeStep(protoStep);
     expect(response.getOutcome()).to.equal(RunStepResponse.Outcome.ERROR);


### PR DESCRIPTION
With this PR, it will be possible to specify `be less than`, `be greater than`, `contain`, `not contain`, or `not be`, in addition to the previous, sole, hard-coded `be` operator.